### PR TITLE
Update license information and package.json

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2014-2017 Analytical Graphics, Inc. and Contributors
+Copyright 2014-2022 Analytical Graphics, Inc. and Contributors
 
                                  Apache License
                            Version 2.0, January 2004
@@ -207,7 +207,7 @@ Original Work
 
 Code samples were ported from [earth-api-samples](https://code.google.com/p/earth-api-samples/).
 
-Copyright 2008-2014 Google Inc.
+Copyright 2008-2022 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -230,7 +230,7 @@ This project includes the following third-party code.
 
 http://cesiumjs.org/
 
-Copyright 2011-2014 Cesium Contributors
+Copyright 2011-2022 Cesium Contributors
 
 > Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 >

--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "CesiumJS",
+        "license": ["Apache-2.0"],
+        "version": "1.37",
+        "url": "https://github.com/CesiumGS/cesium"
+    }
+]

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-    "name": "cesium-starter-app",
+    "name": "cesium-google-earth-examples",
     "version": "1.4.0",
-    "description": "A simple JavaScript starter app for creating apps with Cesium, the open-source WebGL virtual globe and map engine.",
-    "homepage": "http://cesiumjs.org",
+    "description": "Google Earth plugin API samples ported to Cesium, the open-source WebGL virtual globe and map engine.",
+    "homepage": "http://cesium.com/cesiumjs/",
     "license": "Apache-2.0",
+    "author": {
+      "name": "Cesium GS, Inc.",
+      "url": "https://cesium.com"
+    },
     "repository": {
         "type": "git",
-        "url": "hhttps://github.com/pjcozzi/cesium-starter-app"
+        "url": "https://github.com/CesiumGS/cesium-google-earth-examples"
     },
-    "dependencies": {
+    "devDependencies": {
       "express": "~4.9.x",
-        "compression": "1.0.8",
-        "request": "2.36.0",
-        "yargs": "1.2.6"
-    },
-    "engines": {
-      "node": "0.10.x"
+      "compression": "1.0.8",
+      "request": "2.36.0",
+      "yargs": "1.2.6"
     }
 }


### PR DESCRIPTION
Updates licensing information to align with the [strategy now used in CesiumJS](https://github.com/CesiumGS/cesium/pull/10295).

The `package.json` file was also inaccurate in a few place, so that's been cleaned up as well.

@sanjeetsuhag Could you please review after https://github.com/CesiumGS/cesium/pull/10295?